### PR TITLE
Attribute adapter spigot+1.20.6+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@ name: Build
 on:
   push:
   pull_request:
+    types:
+      - opened
+      - reopened
 
 env:
   USERNAME: ${{ secrets.GITHUB_TOKEN }}

--- a/core/src/main/java/com/wizardlybump17/wlib/WLib.java
+++ b/core/src/main/java/com/wizardlybump17/wlib/WLib.java
@@ -1,5 +1,6 @@
 package com.wizardlybump17.wlib;
 
+import com.wizardlybump17.wlib.adapter.AttributeAdapter;
 import com.wizardlybump17.wlib.adapter.ItemAdapter;
 import com.wizardlybump17.wlib.adapter.player.PlayerAdapter;
 import com.wizardlybump17.wlib.command.args.ArgsReaderRegistry;
@@ -117,14 +118,17 @@ public class WLib extends JavaPlugin {
             case "1.20.5", "1.20.6" -> {
                 ItemAdapter.setInstance(new com.wizardlybump17.wlib.adapter.v1_20_R4.ItemAdapter());
                 PlayerAdapter.setInstance(new com.wizardlybump17.wlib.adapter.v1_20_R4.player.PlayerAdapter());
+                AttributeAdapter.setInstance(new com.wizardlybump17.wlib.adapter.v1_20_R4.AttributeAdapter());
             }
             case "1.21", "1.21.1" -> {
                 ItemAdapter.setInstance(new com.wizardlybump17.wlib.adapter.v1_21_R1.ItemAdapter());
                 PlayerAdapter.setInstance(new com.wizardlybump17.wlib.adapter.v1_21_R1.player.PlayerAdapter());
+                AttributeAdapter.setInstance(new com.wizardlybump17.wlib.adapter.v1_21_R1.AttributeAdapter());
             }
             case "1.21.4" -> {
                 ItemAdapter.setInstance(new com.wizardlybump17.wlib.adapter.v1_21_R3.ItemAdapter());
                 PlayerAdapter.setInstance(new com.wizardlybump17.wlib.adapter.v1_21_R3.player.PlayerAdapter());
+                AttributeAdapter.setInstance(new com.wizardlybump17.wlib.adapter.v1_21_R3.AttributeAdapter());
             }
             default -> getLogger().severe("The server version (" + version + ") is not supported by WLib yet.");
         }

--- a/core/src/main/java/com/wizardlybump17/wlib/item/ItemBuilder.java
+++ b/core/src/main/java/com/wizardlybump17/wlib/item/ItemBuilder.java
@@ -2,6 +2,7 @@ package com.wizardlybump17.wlib.item;
 
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
+import com.wizardlybump17.wlib.adapter.AttributeAdapter;
 import com.wizardlybump17.wlib.adapter.ItemAdapter;
 import com.wizardlybump17.wlib.item.handler.ItemMetaHandler;
 import com.wizardlybump17.wlib.item.handler.model.ItemMetaHandlerModel;
@@ -423,7 +424,7 @@ public class ItemBuilder implements ConfigurationSerializable, Cloneable {
 
         Multimap<Attribute, AttributeModifier> attributes = attributes();
         if (!attributes.isEmpty())
-            result.put("attributes", MapUtils.mapKeys(attributes.asMap(), TreeMap::new, Enum::name));
+            result.put("attributes", AttributeAdapter.getInstance().serialize(attributes));
 
         if (metaHandler != null)
             metaHandler.serialize(result);
@@ -477,15 +478,11 @@ public class ItemBuilder implements ConfigurationSerializable, Cloneable {
                 .glow(ConfigUtil.get("glow", map, () -> null));
 
         Optional
-                .ofNullable(ConfigUtil.<Map<String, Collection<AttributeModifier>>, Map<Attribute, Collection<AttributeModifier>>>map(
+                .ofNullable(ConfigUtil.<Map<String, Collection<AttributeModifier>>, Multimap<Attribute, AttributeModifier>>map(
                         "attributes",
                         map,
                         () -> null,
-                        attributes -> MapUtils.mapKeys(
-                                attributes,
-                                () -> new EnumMap<>(Attribute.class),
-                                type -> Attribute.valueOf(type.toUpperCase())
-                        )
+                        attributes -> AttributeAdapter.getInstance().deserialize(attributes)
                 ))
                 .ifPresent(result::attributes);
 

--- a/versions/adapter/src/main/java/com/wizardlybump17/wlib/adapter/AttributeAdapter.java
+++ b/versions/adapter/src/main/java/com/wizardlybump17/wlib/adapter/AttributeAdapter.java
@@ -1,0 +1,29 @@
+package com.wizardlybump17.wlib.adapter;
+
+import com.google.common.collect.Multimap;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeModifier;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+
+public abstract class AttributeAdapter {
+
+    private static AttributeAdapter instance;
+
+    public abstract Attribute getAttribute(@NotNull String name);
+
+    public abstract @NotNull Map<String, Object> serialize(@NotNull Multimap<Attribute, AttributeModifier> attributes);
+
+    public abstract @NotNull Multimap<Attribute, AttributeModifier> deserialize(@NotNull Map<String, ? extends Object> serialized);
+
+    public static AttributeAdapter getInstance() {
+        return instance;
+    }
+
+    public static void setInstance(@NotNull AttributeAdapter instance) {
+        if (AttributeAdapter.instance != null)
+            throw new IllegalStateException("The AttributeAdapter is already set");
+        AttributeAdapter.instance = instance;
+    }
+}

--- a/versions/v1_20_R4/src/main/java/com/wizardlybump17/wlib/adapter/v1_20_R4/AttributeAdapter.java
+++ b/versions/v1_20_R4/src/main/java/com/wizardlybump17/wlib/adapter/v1_20_R4/AttributeAdapter.java
@@ -1,0 +1,48 @@
+package com.wizardlybump17.wlib.adapter.v1_20_R4;
+
+import com.google.common.collect.Multimap;
+import com.google.common.collect.TreeMultimap;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeModifier;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+
+public class AttributeAdapter extends com.wizardlybump17.wlib.adapter.AttributeAdapter {
+
+    @Override
+    public Attribute getAttribute(@NotNull String name) {
+        try {
+            return Attribute.valueOf(name.toUpperCase());
+        } catch (IllegalArgumentException ignored) {
+            return Registry.ATTRIBUTE.get(NamespacedKey.fromString(name.toLowerCase()));
+        }
+    }
+
+    @Override
+    public @NotNull Map<String, Object> serialize(@NotNull Multimap<Attribute, AttributeModifier> attributes) {
+        Map<String, Object> result = new TreeMap<>();
+        for (Attribute attribute : attributes.keySet())
+            result.put(attribute.getKey().toString(), List.copyOf(attributes.get(attribute)));
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public @NotNull Multimap<Attribute, AttributeModifier> deserialize(@NotNull Map<String, ? extends Object> serialized) {
+        Multimap<Attribute, AttributeModifier> result = TreeMultimap.create(
+                Comparator.comparing(attribute -> attribute.getKey().toString()),
+                Comparator.<AttributeModifier, String>comparing(modifier -> modifier.getUniqueId().toString())
+                        .thenComparing(AttributeModifier::getAmount)
+                        .thenComparing(AttributeModifier::getOperation)
+        );
+        serialized.forEach((attribute, modifiers) -> {
+            if (modifiers != null)
+                for (AttributeModifier modifier : ((Collection<AttributeModifier>) modifiers))
+                    result.put(getAttribute(attribute), modifier);
+        });
+        return result;
+    }
+}

--- a/versions/v1_21_R1/src/main/java/com/wizardlybump17/wlib/adapter/v1_21_R1/AttributeAdapter.java
+++ b/versions/v1_21_R1/src/main/java/com/wizardlybump17/wlib/adapter/v1_21_R1/AttributeAdapter.java
@@ -1,0 +1,48 @@
+package com.wizardlybump17.wlib.adapter.v1_21_R1;
+
+import com.google.common.collect.Multimap;
+import com.google.common.collect.TreeMultimap;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeModifier;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+
+public class AttributeAdapter extends com.wizardlybump17.wlib.adapter.AttributeAdapter {
+
+    @Override
+    public Attribute getAttribute(@NotNull String name) {
+        try {
+            return Attribute.valueOf(name.toUpperCase());
+        } catch (IllegalArgumentException ignored) {
+            return Registry.ATTRIBUTE.get(NamespacedKey.fromString(name.toLowerCase()));
+        }
+    }
+
+    @Override
+    public @NotNull Map<String, Object> serialize(@NotNull Multimap<Attribute, AttributeModifier> attributes) {
+        Map<String, Object> result = new TreeMap<>();
+        for (Attribute attribute : attributes.keySet())
+            result.put(attribute.getKey().toString(), List.copyOf(attributes.get(attribute)));
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public @NotNull Multimap<Attribute, AttributeModifier> deserialize(@NotNull Map<String, ? extends Object> serialized) {
+        Multimap<Attribute, AttributeModifier> result = TreeMultimap.create(
+                Comparator.comparing(attribute -> attribute.getKey().toString()),
+                Comparator.<AttributeModifier, String>comparing(modifier -> modifier.getKey().toString())
+                        .thenComparing(AttributeModifier::getAmount)
+                        .thenComparing(AttributeModifier::getOperation)
+        );
+        serialized.forEach((attribute, modifiers) -> {
+            if (modifiers != null)
+                for (AttributeModifier modifier : ((Collection<AttributeModifier>) modifiers))
+                    result.put(getAttribute(attribute), modifier);
+        });
+        return result;
+    }
+}

--- a/versions/v1_21_R3/src/main/java/com/wizardlybump17/wlib/adapter/v1_21_R3/AttributeAdapter.java
+++ b/versions/v1_21_R3/src/main/java/com/wizardlybump17/wlib/adapter/v1_21_R3/AttributeAdapter.java
@@ -1,0 +1,76 @@
+package com.wizardlybump17.wlib.adapter.v1_21_R3;
+
+import com.google.common.collect.Multimap;
+import com.google.common.collect.TreeMultimap;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeModifier;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+
+public class AttributeAdapter extends com.wizardlybump17.wlib.adapter.AttributeAdapter {
+
+    public static final @NotNull Map<String, Attribute> ATTRIBUTES;
+
+    static {
+        Map<String, Attribute> attributes = new HashMap<>();
+        attributes.put("GENERIC_MAX_HEALTH", Attribute.MAX_HEALTH);
+        attributes.put("GENERIC_FOLLOW_RANGE", Attribute.FOLLOW_RANGE);
+        attributes.put("GENERIC_KNOCKBACK_RESISTANCE", Attribute.KNOCKBACK_RESISTANCE);
+        attributes.put("GENERIC_MOVEMENT_SPEED", Attribute.MOVEMENT_SPEED);
+        attributes.put("GENERIC_FLYING_SPEED", Attribute.FLYING_SPEED);
+        attributes.put("GENERIC_ATTACK_DAMAGE", Attribute.ATTACK_DAMAGE);
+        attributes.put("GENERIC_ATTACK_KNOCKBACK", Attribute.ATTACK_KNOCKBACK);
+        attributes.put("GENERIC_ATTACK_SPEED", Attribute.ATTACK_SPEED);
+        attributes.put("GENERIC_ARMOR", Attribute.ARMOR);
+        attributes.put("GENERIC_ARMOR_TOUGHNESS", Attribute.ARMOR_TOUGHNESS);
+        attributes.put("GENERIC_FALL_DAMAGE_MULTIPLIER", Attribute.FALL_DAMAGE_MULTIPLIER);
+        attributes.put("GENERIC_LUCK", Attribute.LUCK);
+        attributes.put("GENERIC_MAX_ABSORPTION", Attribute.MAX_ABSORPTION);
+        attributes.put("GENERIC_SAFE_FALL_DISTANCE", Attribute.SAFE_FALL_DISTANCE);
+        attributes.put("GENERIC_SCALE", Attribute.SCALE);
+        attributes.put("GENERIC_STEP_HEIGHT", Attribute.STEP_HEIGHT);
+        attributes.put("GENERIC_GRAVITY", Attribute.GRAVITY);
+        attributes.put("GENERIC_JUMP_STRENGTH", Attribute.JUMP_STRENGTH);
+        attributes.put("PLAYER_BLOCK_INTERACTION_RANGE", Attribute.BLOCK_INTERACTION_RANGE);
+        attributes.put("PLAYER_ENTITY_INTERACTION_RANGE", Attribute.ENTITY_INTERACTION_RANGE);
+        attributes.put("PLAYER_BLOCK_BREAK_SPEED", Attribute.BLOCK_BREAK_SPEED);
+        attributes.put("ZOMBIE_SPAWN_REINFORCEMENTS", Attribute.SPAWN_REINFORCEMENTS);
+        ATTRIBUTES = Collections.unmodifiableMap(attributes);
+    }
+
+    @Override
+    public Attribute getAttribute(@NotNull String name) {
+        Attribute converted = ATTRIBUTES.get(name.toUpperCase());
+        if (converted != null)
+            return converted;
+        return Registry.ATTRIBUTE.get(NamespacedKey.fromString(name.toLowerCase()));
+    }
+
+    @Override
+    public @NotNull Map<String, Object> serialize(@NotNull Multimap<Attribute, AttributeModifier> attributes) {
+        Map<String, Object> result = new TreeMap<>();
+        for (Attribute attribute : attributes.keySet())
+            result.put(attribute.getKey().toString(), List.copyOf(attributes.get(attribute)));
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public @NotNull Multimap<Attribute, AttributeModifier> deserialize(@NotNull Map<String, ? extends Object> serialized) {
+        Multimap<Attribute, AttributeModifier> result = TreeMultimap.create(
+                Comparator.comparing(attribute -> attribute.getKey().toString()),
+                Comparator.<AttributeModifier, String>comparing(modifier -> modifier.getKey().toString())
+                        .thenComparing(AttributeModifier::getAmount)
+                        .thenComparing(AttributeModifier::getOperation)
+        );
+        serialized.forEach((attribute, modifiers) -> {
+            if (modifiers != null)
+                for (AttributeModifier modifier : ((Collection<AttributeModifier>) modifiers))
+                    result.put(getAttribute(attribute), modifier);
+        });
+        return result;
+    }
+}


### PR DESCRIPTION
This Pull Request reworks adds Attribute Adapter system.
This system is used to convert old Attributes into new ones. It also adds an abstract method to serialize and deserialize attribute modifiers.