### PR TITLE
Get and set custom data to items 1.20.6+

### DIFF
--- a/core/src/main/java/com/wizardlybump17/wlib/item/ItemBuilder.java
+++ b/core/src/main/java/com/wizardlybump17/wlib/item/ItemBuilder.java
@@ -435,6 +435,18 @@ public class ItemBuilder implements ConfigurationSerializable, Cloneable {
         return this;
     }
 
+    public @NotNull Map<String, Object> itemCustomData() {
+        if (itemMeta == null)
+            return new HashMap<>();
+        return ItemAdapter.getInstance().getCustomData(itemMeta);
+    }
+
+    public @NotNull ItemBuilder itemCustomData(@NotNull Map<String, Object> customData) {
+        if (itemMeta != null)
+            ItemAdapter.getInstance().setCustomData(itemMeta, customData);
+        return this;
+    }
+
     @Override
     @NotNull
     public Map<String, Object> serialize() {
@@ -467,6 +479,10 @@ public class ItemBuilder implements ConfigurationSerializable, Cloneable {
         Multimap<Attribute, AttributeModifier> attributes = attributes();
         if (!attributes.isEmpty())
             result.put("attributes", AttributeAdapter.getInstance().serialize(attributes));
+
+        Map<String, Object> itemCustomData = itemCustomData();
+        if (!itemCustomData.isEmpty())
+            result.put("item-custom-data", new TreeMap<>(itemCustomData));
 
         if (metaHandler != null)
             metaHandler.serialize(result);
@@ -533,6 +549,14 @@ public class ItemBuilder implements ConfigurationSerializable, Cloneable {
                         attributes -> AttributeAdapter.getInstance().deserialize(attributes)
                 ))
                 .ifPresent(result::attributes);
+
+        Optional
+                .ofNullable(ConfigUtil.<Map<String, Object>>get(
+                        "item-custom-data",
+                        map,
+                        Map::of
+                ))
+                .ifPresent(result::itemCustomData);
 
         ItemMetaHandlerModel<?> metaHandlerModel = ItemMetaHandlerModel.getApplicableModel(result.type());
         result.metaHandler(metaHandlerModel == null ? null : metaHandlerModel.createHandler(result));

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/versions/adapter/src/main/java/com/wizardlybump17/wlib/adapter/ItemAdapter.java
+++ b/versions/adapter/src/main/java/com/wizardlybump17/wlib/adapter/ItemAdapter.java
@@ -9,6 +9,8 @@ import org.bukkit.persistence.PersistentDataContainer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Map;
+
 public abstract class ItemAdapter {
 
     public static final PersistentDataAdapterContext PERSISTENT_DATA_ADAPTER_CONTEXT = new ItemStack(Material.BOW).getItemMeta().getPersistentDataContainer().getAdapterContext();
@@ -30,4 +32,12 @@ public abstract class ItemAdapter {
     public abstract void setDamage(@NotNull ItemMeta meta, @Nullable Integer damage);
 
     public abstract @Nullable Integer getDamage(@NotNull ItemMeta meta);
+
+    public abstract @NotNull Map<String, Object> getCustomData(@NotNull ItemMeta meta);
+
+    public abstract void setCustomData(@NotNull ItemMeta meta, @NotNull Map<String, Object> customData);
+
+    protected abstract @NotNull Object toNBT(@NotNull Object java);
+
+    protected abstract @NotNull Object fromNBT(@NotNull Object nbt);
 }

--- a/versions/v1_20_R4/build.gradle.kts
+++ b/versions/v1_20_R4/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 apply(plugin = "io.papermc.paperweight.userdev")
 
-val paper = "1.20.6-R0.1-20240702.153951-123"
+val paper = "1.20.6-R0.1-SNAPSHOT"
 val lombok = "1.18.32"
 val jetbrainsAnnotations = "24.1.0"
 

--- a/versions/v1_20_R4/src/main/java/com/wizardlybump17/wlib/adapter/v1_20_R4/ItemAdapter.java
+++ b/versions/v1_20_R4/src/main/java/com/wizardlybump17/wlib/adapter/v1_20_R4/ItemAdapter.java
@@ -1,7 +1,8 @@
 package com.wizardlybump17.wlib.adapter.v1_20_R4;
 
+import com.wizardlybump17.wlib.util.ReflectionUtil;
 import lombok.NonNull;
-import net.minecraft.nbt.Tag;
+import net.minecraft.nbt.*;
 import org.bukkit.craftbukkit.persistence.CraftPersistentDataContainer;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -9,9 +10,13 @@ import org.bukkit.persistence.PersistentDataContainer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Map;
+import java.lang.reflect.Field;
+import java.util.*;
 
 public class ItemAdapter extends com.wizardlybump17.wlib.adapter.ItemAdapter {
+
+    public static final @NotNull Class<?> CRAFT_META_ITEM = ReflectionUtil.getClass("org.bukkit.craftbukkit.inventory.CraftMetaItem");
+    public static final @NotNull Field CUSTOM_TAG = ReflectionUtil.getField("customTag", CRAFT_META_ITEM);
 
     @Override
     public void transferPersistentData(@NonNull PersistentDataContainer from, @NonNull PersistentDataContainer to) {
@@ -34,5 +39,114 @@ public class ItemAdapter extends com.wizardlybump17.wlib.adapter.ItemAdapter {
     @Override
     public @Nullable Integer getDamage(@NotNull ItemMeta meta) {
         return meta instanceof Damageable damageable && damageable.hasDamage() ? damageable.getDamage() : null;
+    }
+
+    @Override
+    public @NotNull Map<String, Object> getCustomData(@NotNull ItemMeta meta) {
+        Map<String, Object> result = new HashMap<>();
+
+        CompoundTag tag = ReflectionUtil.getFieldValue(CUSTOM_TAG, meta);
+
+        for (String key : tag.getAllKeys()) {
+            Tag data = tag.get(key);
+            if (data != null)
+                result.put(key, fromNBT(data));
+        }
+
+        return result;
+    }
+
+    @Override
+    public void setCustomData(@NotNull ItemMeta meta, @NotNull Map<String, Object> customData) {
+        CompoundTag tag = new CompoundTag();
+        for (Map.Entry<String, Object> entry : customData.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+            tag.put(key, toNBT(value));
+        }
+
+        ReflectionUtil.setFieldValue(CUSTOM_TAG, meta, tag);
+    }
+
+    @Override
+    protected @NotNull Tag toNBT(@NotNull Object java) {
+        return switch (java) {
+            case Byte b -> ByteTag.valueOf(b);
+            case Short s -> ShortTag.valueOf(s);
+            case Integer i -> IntTag.valueOf(i);
+            case Long l -> LongTag.valueOf(l);
+            case Float f -> FloatTag.valueOf(f);
+            case Double d -> DoubleTag.valueOf(d);
+
+            case Boolean b -> ByteTag.valueOf(b);
+
+            case String string -> StringTag.valueOf(string);
+
+            case byte[] byteArray -> new ByteArrayTag(byteArray);
+            case Byte[] byteArray -> new ByteArrayTag(List.of(byteArray));
+            case int[] intArray -> new IntArrayTag(intArray);
+            case Integer[] intArray -> new IntArrayTag(List.of(intArray));
+            case long[] longArray -> new LongArrayTag(longArray);
+            case Long[] longArray -> new LongArrayTag(List.of(longArray));
+
+            case Collection<?> collection -> {
+                List<Tag> values = new ArrayList<>(collection.size());
+                byte type = (byte) 0;
+                for (Object object : collection) {
+                    Tag tag = toNBT(object);
+                    values.add(tag);
+                    type = tag.getId();
+                }
+                yield new ListTag(values, type);
+            }
+
+            case Map<?, ?> map -> {
+                Map<String, Tag> values = new HashMap<>(map.size());
+                map.forEach((key, value) -> values.put(String.valueOf(key), toNBT(value)));
+
+                CompoundTag tag = new CompoundTag();
+                values.forEach(tag::put);
+                yield tag;
+            }
+
+            default -> throw new UnsupportedOperationException("Unsupported Java type: " + java);
+        };
+    }
+
+    @Override
+    protected @NotNull Object fromNBT(@NotNull Object nbt) {
+        return switch (nbt) {
+            case ByteTag tag -> tag.getAsByte();
+            case ShortTag tag -> tag.getAsShort();
+            case IntTag tag -> tag.getAsInt();
+            case LongTag tag -> tag.getAsLong();
+            case FloatTag tag -> tag.getAsFloat();
+            case DoubleTag tag -> tag.getAsDouble();
+
+            case StringTag tag -> tag.getAsString();
+
+            case ByteArrayTag tag -> tag.getAsByteArray();
+            case IntArrayTag tag -> tag.getAsIntArray();
+            case LongArrayTag tag -> tag.getAsLongArray();
+
+            case CollectionTag<?> tag -> {
+                List<Object> list = new ArrayList<>(tag.size());
+                for (Tag value : tag)
+                    list.add(fromNBT(value));
+                yield list;
+            }
+
+            case CompoundTag tag -> {
+                Map<String, Object> map = new HashMap<>(tag.size());
+                for (String key : tag.getAllKeys()) {
+                    Tag value = tag.get(key);
+                    if (value != null)
+                        map.put(key, fromNBT(value));
+                }
+                yield map;
+            }
+
+            default -> throw new UnsupportedOperationException("Unsupported NBT type: " + nbt);
+        };
     }
 }

--- a/versions/v1_21_R1/build.gradle.kts
+++ b/versions/v1_21_R1/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 apply(plugin = "io.papermc.paperweight.userdev")
 
-val paper = "1.21.1-R0.1-20241121.101634-127"
+val paper = "1.21.1-R0.1-SNAPSHOT"
 val lombok = "1.18.32"
 val jetbrainsAnnotations = "24.1.0"
 

--- a/versions/v1_21_R1/src/main/java/com/wizardlybump17/wlib/adapter/v1_21_R1/ItemAdapter.java
+++ b/versions/v1_21_R1/src/main/java/com/wizardlybump17/wlib/adapter/v1_21_R1/ItemAdapter.java
@@ -1,7 +1,8 @@
 package com.wizardlybump17.wlib.adapter.v1_21_R1;
 
+import com.wizardlybump17.wlib.util.ReflectionUtil;
 import lombok.NonNull;
-import net.minecraft.nbt.Tag;
+import net.minecraft.nbt.*;
 import org.bukkit.craftbukkit.persistence.CraftPersistentDataContainer;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -9,9 +10,13 @@ import org.bukkit.persistence.PersistentDataContainer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Map;
+import java.lang.reflect.Field;
+import java.util.*;
 
 public class ItemAdapter extends com.wizardlybump17.wlib.adapter.ItemAdapter {
+
+    public static final @NotNull Class<?> CRAFT_META_ITEM = ReflectionUtil.getClass("org.bukkit.craftbukkit.inventory.CraftMetaItem");
+    public static final @NotNull Field CUSTOM_TAG = ReflectionUtil.getField("customTag", CRAFT_META_ITEM);
 
     @Override
     public void transferPersistentData(@NonNull PersistentDataContainer from, @NonNull PersistentDataContainer to) {
@@ -39,5 +44,114 @@ public class ItemAdapter extends com.wizardlybump17.wlib.adapter.ItemAdapter {
     @Override
     public @Nullable Integer getDamage(@NotNull ItemMeta meta) {
         return meta instanceof Damageable damageable && damageable.hasDamage() ? damageable.getDamage() : null;
+    }
+
+    @Override
+    public @NotNull Map<String, Object> getCustomData(@NotNull ItemMeta meta) {
+        Map<String, Object> result = new HashMap<>();
+
+        CompoundTag tag = ReflectionUtil.getFieldValue(CUSTOM_TAG, meta);
+
+        for (String key : tag.getAllKeys()) {
+            Tag data = tag.get(key);
+            if (data != null)
+                result.put(key, fromNBT(data));
+        }
+
+        return result;
+    }
+
+    @Override
+    public void setCustomData(@NotNull ItemMeta meta, @NotNull Map<String, Object> customData) {
+        CompoundTag tag = new CompoundTag();
+        for (Map.Entry<String, Object> entry : customData.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+            tag.put(key, toNBT(value));
+        }
+
+        ReflectionUtil.setFieldValue(CUSTOM_TAG, meta, tag);
+    }
+
+    @Override
+    protected @NotNull Tag toNBT(@NotNull Object java) {
+        return switch (java) {
+            case Byte b -> ByteTag.valueOf(b);
+            case Short s -> ShortTag.valueOf(s);
+            case Integer i -> IntTag.valueOf(i);
+            case Long l -> LongTag.valueOf(l);
+            case Float f -> FloatTag.valueOf(f);
+            case Double d -> DoubleTag.valueOf(d);
+
+            case Boolean b -> ByteTag.valueOf(b);
+
+            case String string -> StringTag.valueOf(string);
+
+            case byte[] byteArray -> new ByteArrayTag(byteArray);
+            case Byte[] byteArray -> new ByteArrayTag(List.of(byteArray));
+            case int[] intArray -> new IntArrayTag(intArray);
+            case Integer[] intArray -> new IntArrayTag(List.of(intArray));
+            case long[] longArray -> new LongArrayTag(longArray);
+            case Long[] longArray -> new LongArrayTag(List.of(longArray));
+
+            case Collection<?> collection -> {
+                List<Tag> values = new ArrayList<>(collection.size());
+                byte type = (byte) 0;
+                for (Object object : collection) {
+                    Tag tag = toNBT(object);
+                    values.add(tag);
+                    type = tag.getId();
+                }
+                yield new ListTag(values, type);
+            }
+
+            case Map<?, ?> map -> {
+                Map<String, Tag> values = new HashMap<>(map.size());
+                map.forEach((key, value) -> values.put(String.valueOf(key), toNBT(value)));
+
+                CompoundTag tag = new CompoundTag();
+                values.forEach(tag::put);
+                yield tag;
+            }
+
+            default -> throw new UnsupportedOperationException("Unsupported Java type: " + java);
+        };
+    }
+
+    @Override
+    protected @NotNull Object fromNBT(@NotNull Object nbt) {
+        return switch (nbt) {
+            case ByteTag tag -> tag.getAsByte();
+            case ShortTag tag -> tag.getAsShort();
+            case IntTag tag -> tag.getAsInt();
+            case LongTag tag -> tag.getAsLong();
+            case FloatTag tag -> tag.getAsFloat();
+            case DoubleTag tag -> tag.getAsDouble();
+
+            case StringTag tag -> tag.getAsString();
+
+            case ByteArrayTag tag -> tag.getAsByteArray();
+            case IntArrayTag tag -> tag.getAsIntArray();
+            case LongArrayTag tag -> tag.getAsLongArray();
+
+            case CollectionTag<?> tag -> {
+                List<Object> list = new ArrayList<>(tag.size());
+                for (Tag value : tag)
+                    list.add(fromNBT(value));
+                yield list;
+            }
+
+            case CompoundTag tag -> {
+                Map<String, Object> map = new HashMap<>(tag.size());
+                for (String key : tag.getAllKeys()) {
+                    Tag value = tag.get(key);
+                    if (value != null)
+                        map.put(key, fromNBT(value));
+                }
+                yield map;
+            }
+
+            default -> throw new UnsupportedOperationException("Unsupported NBT type: " + nbt);
+        };
     }
 }

--- a/versions/v1_21_R3/build.gradle.kts
+++ b/versions/v1_21_R3/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 apply(plugin = "io.papermc.paperweight.userdev")
 
-val paper = "1.21.4-R0.1-20250317.101324-208"
+val paper = "1.21.4-R0.1-SNAPSHOT"
 val lombok = "1.18.32"
 val jetbrainsAnnotations = "24.1.0"
 

--- a/versions/v1_21_R3/src/main/java/com/wizardlybump17/wlib/adapter/v1_21_R3/ItemAdapter.java
+++ b/versions/v1_21_R3/src/main/java/com/wizardlybump17/wlib/adapter/v1_21_R3/ItemAdapter.java
@@ -1,7 +1,8 @@
 package com.wizardlybump17.wlib.adapter.v1_21_R3;
 
+import com.wizardlybump17.wlib.util.ReflectionUtil;
 import lombok.NonNull;
-import net.minecraft.nbt.Tag;
+import net.minecraft.nbt.*;
 import org.bukkit.craftbukkit.persistence.CraftPersistentDataContainer;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -9,9 +10,13 @@ import org.bukkit.persistence.PersistentDataContainer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Map;
+import java.lang.reflect.Field;
+import java.util.*;
 
 public class ItemAdapter extends com.wizardlybump17.wlib.adapter.ItemAdapter {
+
+    public static final @NotNull Class<?> CRAFT_META_ITEM = ReflectionUtil.getClass("org.bukkit.craftbukkit.inventory.CraftMetaItem");
+    public static final @NotNull Field CUSTOM_TAG = ReflectionUtil.getField("customTag", CRAFT_META_ITEM);
 
     @Override
     public void transferPersistentData(@NonNull PersistentDataContainer from, @NonNull PersistentDataContainer to) {
@@ -39,5 +44,114 @@ public class ItemAdapter extends com.wizardlybump17.wlib.adapter.ItemAdapter {
     @Override
     public @Nullable Integer getDamage(@NotNull ItemMeta meta) {
         return meta instanceof Damageable damageable && damageable.hasDamage() ? damageable.getDamage() : null;
+    }
+
+    @Override
+    public @NotNull Map<String, Object> getCustomData(@NotNull ItemMeta meta) {
+        Map<String, Object> result = new HashMap<>();
+
+        CompoundTag tag = ReflectionUtil.getFieldValue(CUSTOM_TAG, meta);
+
+        for (String key : tag.getAllKeys()) {
+            Tag data = tag.get(key);
+            if (data != null)
+                result.put(key, fromNBT(data));
+        }
+
+        return result;
+    }
+
+    @Override
+    public void setCustomData(@NotNull ItemMeta meta, @NotNull Map<String, Object> customData) {
+        CompoundTag tag = new CompoundTag();
+        for (Map.Entry<String, Object> entry : customData.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+            tag.put(key, toNBT(value));
+        }
+
+        ReflectionUtil.setFieldValue(CUSTOM_TAG, meta, tag);
+    }
+
+    @Override
+    protected @NotNull Tag toNBT(@NotNull Object java) {
+        return switch (java) {
+            case Byte b -> ByteTag.valueOf(b);
+            case Short s -> ShortTag.valueOf(s);
+            case Integer i -> IntTag.valueOf(i);
+            case Long l -> LongTag.valueOf(l);
+            case Float f -> FloatTag.valueOf(f);
+            case Double d -> DoubleTag.valueOf(d);
+
+            case Boolean b -> ByteTag.valueOf(b);
+
+            case String string -> StringTag.valueOf(string);
+
+            case byte[] byteArray -> new ByteArrayTag(byteArray);
+            case Byte[] byteArray -> new ByteArrayTag(List.of(byteArray));
+            case int[] intArray -> new IntArrayTag(intArray);
+            case Integer[] intArray -> new IntArrayTag(List.of(intArray));
+            case long[] longArray -> new LongArrayTag(longArray);
+            case Long[] longArray -> new LongArrayTag(List.of(longArray));
+
+            case Collection<?> collection -> {
+                List<Tag> values = new ArrayList<>(collection.size());
+                byte type = (byte) 0;
+                for (Object object : collection) {
+                    Tag tag = toNBT(object);
+                    values.add(tag);
+                    type = tag.getId();
+                }
+                yield new ListTag(values, type);
+            }
+
+            case Map<?, ?> map -> {
+                Map<String, Tag> values = new HashMap<>(map.size());
+                map.forEach((key, value) -> values.put(String.valueOf(key), toNBT(value)));
+
+                CompoundTag tag = new CompoundTag();
+                values.forEach(tag::put);
+                yield tag;
+            }
+
+            default -> throw new UnsupportedOperationException("Unsupported Java type: " + java);
+        };
+    }
+
+    @Override
+    protected @NotNull Object fromNBT(@NotNull Object nbt) {
+        return switch (nbt) {
+            case ByteTag tag -> tag.getAsByte();
+            case ShortTag tag -> tag.getAsShort();
+            case IntTag tag -> tag.getAsInt();
+            case LongTag tag -> tag.getAsLong();
+            case FloatTag tag -> tag.getAsFloat();
+            case DoubleTag tag -> tag.getAsDouble();
+
+            case StringTag tag -> tag.getAsString();
+
+            case ByteArrayTag tag -> tag.getAsByteArray();
+            case IntArrayTag tag -> tag.getAsIntArray();
+            case LongArrayTag tag -> tag.getAsLongArray();
+
+            case CollectionTag<?> tag -> {
+                List<Object> list = new ArrayList<>(tag.size());
+                for (Tag value : tag)
+                    list.add(fromNBT(value));
+                yield list;
+            }
+
+            case CompoundTag tag -> {
+                Map<String, Object> map = new HashMap<>(tag.size());
+                for (String key : tag.getAllKeys()) {
+                    Tag value = tag.get(key);
+                    if (value != null)
+                        map.put(key, fromNBT(value));
+                }
+                yield map;
+            }
+
+            default -> throw new UnsupportedOperationException("Unsupported NBT type: " + nbt);
+        };
     }
 }


### PR DESCRIPTION
This Pull Request makes it possible to get and set custom data into items.
The custom data is the one from the `custom_data` component.

The custom data is saved on the config on the `item-custom-data` field and it is a `Map<String, Object>` internally.

Example:
```yaml
item-custom-data:
  itemsadder:
    namespace: animals_hat_v1
    id: capybara
```