### PR TITLE
ItemAdapter#getCustomData(ItemMeta) NullPointerException fix 1.20.6+

### DIFF
--- a/versions/v1_20_R4/src/main/java/com/wizardlybump17/wlib/adapter/v1_20_R4/ItemAdapter.java
+++ b/versions/v1_20_R4/src/main/java/com/wizardlybump17/wlib/adapter/v1_20_R4/ItemAdapter.java
@@ -46,6 +46,8 @@ public class ItemAdapter extends com.wizardlybump17.wlib.adapter.ItemAdapter {
         Map<String, Object> result = new HashMap<>();
 
         CompoundTag tag = ReflectionUtil.getFieldValue(CUSTOM_TAG, meta);
+        if (tag == null)
+            return result;
 
         for (String key : tag.getAllKeys()) {
             Tag data = tag.get(key);

--- a/versions/v1_21_R1/src/main/java/com/wizardlybump17/wlib/adapter/v1_21_R1/ItemAdapter.java
+++ b/versions/v1_21_R1/src/main/java/com/wizardlybump17/wlib/adapter/v1_21_R1/ItemAdapter.java
@@ -51,6 +51,8 @@ public class ItemAdapter extends com.wizardlybump17.wlib.adapter.ItemAdapter {
         Map<String, Object> result = new HashMap<>();
 
         CompoundTag tag = ReflectionUtil.getFieldValue(CUSTOM_TAG, meta);
+        if (tag == null)
+            return result;
 
         for (String key : tag.getAllKeys()) {
             Tag data = tag.get(key);

--- a/versions/v1_21_R3/src/main/java/com/wizardlybump17/wlib/adapter/v1_21_R3/ItemAdapter.java
+++ b/versions/v1_21_R3/src/main/java/com/wizardlybump17/wlib/adapter/v1_21_R3/ItemAdapter.java
@@ -51,6 +51,8 @@ public class ItemAdapter extends com.wizardlybump17.wlib.adapter.ItemAdapter {
         Map<String, Object> result = new HashMap<>();
 
         CompoundTag tag = ReflectionUtil.getFieldValue(CUSTOM_TAG, meta);
+        if (tag == null)
+            return result;
 
         for (String key : tag.getAllKeys()) {
             Tag data = tag.get(key);


### PR DESCRIPTION
This Pull Request fixes a NullPointerException that may happen inside the ItemAdapter#getCustomData(ItemMeta) method. Specifically, the CompoundTag gotten from the CraftMetaItem through reflection can be `null` sometimes.